### PR TITLE
fix New-AzureDatabricksDeltaLakeTable and New-DelimitedText

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Added schema parameter to `New-AzureDatabricksDeltaLakeTable`.
+- Added delta lake support to `New-CopyActivity`.
+- Added CSV specific parameters to `New-DelimitedTextDataset`.
+
 ## [0.2.0] - 2024-10-07
 
 ### Changed

--- a/docs/New-AdfAzureDatabricksDeltaLakeTable.md
+++ b/docs/New-AdfAzureDatabricksDeltaLakeTable.md
@@ -15,7 +15,7 @@ schema: 2.0.0
 ```
 New-AdfAzureDatabricksDeltaLakeTable [-Name] <String> [[-LinkedServiceReference] <PSObject>]
  [[-Parameters] <PSObject>] [[-FolderName] <String>] [-SchemaName] <String> [-TableName] <String>
- [-ProgressAction <ActionPreference>] [<CommonParameters>]
+ [[-Structure] <Object>] [[-Schema] <Object>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -92,6 +92,21 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Schema
+{{ Fill Schema Description }}
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 7
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -SchemaName
 {{ Fill SchemaName Description }}
 
@@ -102,6 +117,21 @@ Aliases:
 
 Required: True
 Position: 4
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Structure
+{{ Fill Structure Description }}
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 6
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/New-AdfAzureDatabricksDeltaLakeTable.md
+++ b/docs/New-AdfAzureDatabricksDeltaLakeTable.md
@@ -15,7 +15,7 @@ schema: 2.0.0
 ```
 New-AdfAzureDatabricksDeltaLakeTable [-Name] <String> [[-LinkedServiceReference] <PSObject>]
  [[-Parameters] <PSObject>] [[-FolderName] <String>] [-SchemaName] <String> [-TableName] <String>
- [[-Structure] <Object>] [[-Schema] <Object>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+ [-UseStructure] [-UseSchema] [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -92,21 +92,6 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Schema
-{{ Fill Schema Description }}
-
-```yaml
-Type: Object
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: 7
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -SchemaName
 {{ Fill SchemaName Description }}
 
@@ -122,21 +107,6 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Structure
-{{ Fill Structure Description }}
-
-```yaml
-Type: Object
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: 6
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -TableName
 {{ Fill TableName Description }}
 
@@ -147,6 +117,36 @@ Aliases:
 
 Required: True
 Position: 5
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -UseSchema
+{{ Fill UseSchema Description }}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -UseStructure
+{{ Fill UseStructure Description }}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/New-AdfAzureDatabricksDeltaLakeTable.md
+++ b/docs/New-AdfAzureDatabricksDeltaLakeTable.md
@@ -15,7 +15,7 @@ schema: 2.0.0
 ```
 New-AdfAzureDatabricksDeltaLakeTable [-Name] <String> [[-LinkedServiceReference] <PSObject>]
  [[-Parameters] <PSObject>] [[-FolderName] <String>] [-SchemaName] <String> [-TableName] <String>
- [-UseStructure] [-UseSchema] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+ [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -117,36 +117,6 @@ Aliases:
 
 Required: True
 Position: 5
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -UseSchema
-{{ Fill UseSchema Description }}
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -UseStructure
-{{ Fill UseStructure Description }}
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/New-AdfAzureDatabricksDeltaLakeTable.md
+++ b/docs/New-AdfAzureDatabricksDeltaLakeTable.md
@@ -14,8 +14,8 @@ schema: 2.0.0
 
 ```
 New-AdfAzureDatabricksDeltaLakeTable [-Name] <String> [[-LinkedServiceReference] <PSObject>]
- [[-Parameters] <PSObject>] [[-FolderName] <String>] [-TableName] <Object> [-ProgressAction <ActionPreference>]
- [<CommonParameters>]
+ [[-Parameters] <PSObject>] [[-FolderName] <String>] [-SchemaName] <String> [-TableName] <String>
+ [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -92,16 +92,31 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -TableName
-{{ Fill TableName Description }}
+### -SchemaName
+{{ Fill SchemaName Description }}
 
 ```yaml
-Type: Object
+Type: String
 Parameter Sets: (All)
 Aliases:
 
 Required: True
 Position: 4
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TableName
+{{ Fill TableName Description }}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 5
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/New-AdfAzureSqlTable.md
+++ b/docs/New-AdfAzureSqlTable.md
@@ -14,7 +14,7 @@ schema: 2.0.0
 
 ```
 New-AdfAzureSqlTable [-Name] <String> [[-LinkedServiceReference] <PSObject>] [[-Parameters] <PSObject>]
- [[-FolderName] <String>] [-TableName] <Object> [<CommonParameters>]
+ [[-FolderName] <String>] [-TableName] <Object> [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -101,6 +101,21 @@ Aliases:
 
 Required: True
 Position: 4
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProgressAction
+{{ Fill ProgressAction Description }}
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/New-AdfDelimitedTextDataset.md
+++ b/docs/New-AdfDelimitedTextDataset.md
@@ -15,7 +15,7 @@ schema: 2.0.0
 ```
 New-AdfDelimitedTextDataset [-Name] <String> [[-LinkedServiceReference] <PSObject>] [[-Parameters] <PSObject>]
  [[-FolderName] <String>] [-Location] <PSObject> [-ColumnDelimiter] <String> [-EscapeChar] <String>
- [-FirstRowAsHeader] <Boolean> [-QuoteChar] <String> [[-Structure] <Object>] [[-Schema] <Object>]
+ [-FirstRowAsHeader] <Boolean> [-QuoteChar] <String> [-UseStructure] [-UseSchema]
  [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
@@ -168,31 +168,31 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Schema
-{{ Fill Schema Description }}
+### -UseSchema
+{{ Fill UseSchema Description }}
 
 ```yaml
-Type: Object
+Type: SwitchParameter
 Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 10
+Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Structure
-{{ Fill Structure Description }}
+### -UseStructure
+{{ Fill UseStructure Description }}
 
 ```yaml
-Type: Object
+Type: SwitchParameter
 Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 9
+Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/New-AdfDelimitedTextDataset.md
+++ b/docs/New-AdfDelimitedTextDataset.md
@@ -15,7 +15,8 @@ schema: 2.0.0
 ```
 New-AdfDelimitedTextDataset [-Name] <String> [[-LinkedServiceReference] <PSObject>] [[-Parameters] <PSObject>]
  [[-FolderName] <String>] [-Location] <PSObject> [-ColumnDelimiter] <String> [-EscapeChar] <String>
- [-FirstRowAsHeader] <Boolean> [-QuoteChar] <String> [-ProgressAction <ActionPreference>] [<CommonParameters>]
+ [-FirstRowAsHeader] <Boolean> [-QuoteChar] <String> [[-Structure] <Object>] [[-Schema] <Object>]
+ [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -162,6 +163,36 @@ Aliases:
 
 Required: True
 Position: 8
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Schema
+{{ Fill Schema Description }}
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 10
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Structure
+{{ Fill Structure Description }}
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 9
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/New-AdfDelimitedTextDataset.md
+++ b/docs/New-AdfDelimitedTextDataset.md
@@ -15,8 +15,7 @@ schema: 2.0.0
 ```
 New-AdfDelimitedTextDataset [-Name] <String> [[-LinkedServiceReference] <PSObject>] [[-Parameters] <PSObject>]
  [[-FolderName] <String>] [-Location] <PSObject> [-ColumnDelimiter] <String> [-EscapeChar] <String>
- [-FirstRowAsHeader] <Boolean> [-QuoteChar] <String> [-UseStructure] [-UseSchema]
- [-ProgressAction <ActionPreference>] [<CommonParameters>]
+ [-FirstRowAsHeader] <Boolean> [-QuoteChar] <String> [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -163,36 +162,6 @@ Aliases:
 
 Required: True
 Position: 8
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -UseSchema
-{{ Fill UseSchema Description }}
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -UseStructure
-{{ Fill UseStructure Description }}
-
-```yaml
-Type: SwitchParameter
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/New-AdfDelimitedTextDataset.md
+++ b/docs/New-AdfDelimitedTextDataset.md
@@ -14,7 +14,8 @@ schema: 2.0.0
 
 ```
 New-AdfDelimitedTextDataset [-Name] <String> [[-LinkedServiceReference] <PSObject>] [[-Parameters] <PSObject>]
- [[-FolderName] <String>] [-TableName] <Object> [-ProgressAction <ActionPreference>] [<CommonParameters>]
+ [[-FolderName] <String>] [-Location] <PSObject> [-ColumnDelimiter] <String> [-EscapeChar] <String>
+ [-FirstRowAsHeader] <Boolean> [-QuoteChar] <String> [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -30,6 +31,51 @@ PS C:\> {{ Add example code here }}
 {{ Add example description here }}
 
 ## PARAMETERS
+
+### -ColumnDelimiter
+{{ Fill ColumnDelimiter Description }}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 5
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -EscapeChar
+{{ Fill EscapeChar Description }}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 6
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -FirstRowAsHeader
+{{ Fill FirstRowAsHeader Description }}
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 7
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 
 ### -FolderName
 {{ Fill FolderName Description }}
@@ -56,6 +102,21 @@ Aliases:
 
 Required: False
 Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Location
+{{ Fill Location Description }}
+
+```yaml
+Type: PSObject
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 4
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -91,16 +152,16 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -TableName
-{{ Fill TableName Description }}
+### -QuoteChar
+{{ Fill QuoteChar Description }}
 
 ```yaml
-Type: Object
+Type: String
 Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 4
+Position: 8
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/src/Internal/New-Dataset.ps1
+++ b/src/Internal/New-Dataset.ps1
@@ -22,7 +22,13 @@ function New-Dataset {
         [PSCustomObject] $Parameters = @{},
 
         [Parameter()]
-        [string] $FolderName
+        [string] $FolderName,
+
+        [Parameter()]
+        $Structure,
+
+        [Parameter()]
+        $Schema
     )
 
     $dataset = [PsCustomObject] @{
@@ -34,11 +40,17 @@ function New-Dataset {
                 'THIS IS A GENERATED DATASET. CHANGES MAY BE OVERWRITTEN!'
             )
             type = $Type
-            structure = @()
             typeProperties = $TypeProperties
-            schema = @()
         }
         type = 'Microsoft.DataFactory/factories/datasets'
+    }
+
+    if ( $Structure ) {
+        $dataset.properties | Add-Member struct $Structure
+    } elseif ( $Schema ) {
+        $dataset.properties | Add-Member schema $Schema
+    } else {
+        $dataset.properties | Add-Member schema @()
     }
 
     if ( $FolderName ) {

--- a/src/Internal/New-Dataset.ps1
+++ b/src/Internal/New-Dataset.ps1
@@ -38,6 +38,7 @@ function New-Dataset {
                 'THIS IS A GENERATED DATASET. CHANGES MAY BE OVERWRITTEN!'
             )
             type = $Type
+            typeProperties = $TypeProperties
         }
         type = 'Microsoft.DataFactory/factories/datasets'
     }

--- a/src/Internal/New-Dataset.ps1
+++ b/src/Internal/New-Dataset.ps1
@@ -25,10 +25,8 @@ function New-Dataset {
         [string] $FolderName,
 
         [Parameter()]
-        [switch] $UseStructure,
-
-        [Parameter()]
-        [switch] $UseSchema
+        [ValidateSet('structure', 'schema')]
+        [string] $StructureOrSchema
     )
 
     $dataset = [PsCustomObject] @{
@@ -40,15 +38,12 @@ function New-Dataset {
                 'THIS IS A GENERATED DATASET. CHANGES MAY BE OVERWRITTEN!'
             )
             type = $Type
-            typeProperties = $TypeProperties
         }
         type = 'Microsoft.DataFactory/factories/datasets'
     }
 
-    if ( $UseStructure ) {
-        $dataset.properties | Add-Member structure @()
-    } elseif ( $UseSchema ) {
-        $dataset.properties | Add-Member schema @()
+    if ( $StructureOrSchema ) {
+        $dataset.properties | Add-Member $StructureOrSchema @()
     }
 
     if ( $FolderName ) {

--- a/src/Internal/New-Dataset.ps1
+++ b/src/Internal/New-Dataset.ps1
@@ -26,7 +26,7 @@ function New-Dataset {
 
         [Parameter()]
         [ValidateSet('structure', 'schema')]
-        [string] $StructureOrSchema
+        [string] $SchemaType
     )
 
     $dataset = [PsCustomObject] @{
@@ -42,8 +42,8 @@ function New-Dataset {
         type = 'Microsoft.DataFactory/factories/datasets'
     }
 
-    if ( $StructureOrSchema ) {
-        $dataset.properties | Add-Member $StructureOrSchema @()
+    if ( $SchemaType ) {
+        $dataset.properties | Add-Member $SchemaType @()
     }
 
     if ( $FolderName ) {

--- a/src/Internal/New-Dataset.ps1
+++ b/src/Internal/New-Dataset.ps1
@@ -25,10 +25,10 @@ function New-Dataset {
         [string] $FolderName,
 
         [Parameter()]
-        $Structure,
+        [switch] $UseStructure,
 
         [Parameter()]
-        $Schema
+        [switch] $UseSchema
     )
 
     $dataset = [PsCustomObject] @{
@@ -45,11 +45,9 @@ function New-Dataset {
         type = 'Microsoft.DataFactory/factories/datasets'
     }
 
-    if ( $Structure ) {
-        $dataset.properties | Add-Member struct $Structure
-    } elseif ( $Schema ) {
-        $dataset.properties | Add-Member schema $Schema
-    } else {
+    if ( $UseStructure ) {
+        $dataset.properties | Add-Member structure @()
+    } elseif ( $UseSchema ) {
         $dataset.properties | Add-Member schema @()
     }
 

--- a/src/Internal/New-Dataset.ps1
+++ b/src/Internal/New-Dataset.ps1
@@ -36,6 +36,7 @@ function New-Dataset {
             type = $Type
             structure = @()
             typeProperties = $TypeProperties
+            schema = @()
         }
         type = 'Microsoft.DataFactory/factories/datasets'
     }

--- a/src/Public/New-AzureDatabricksDeltaLakeTable.ps1
+++ b/src/Public/New-AzureDatabricksDeltaLakeTable.ps1
@@ -25,10 +25,10 @@ function New-AzureDatabricksDeltaLakeTable {
         [string] $TableName,
 
         [Parameter()]
-        $Structure,
+        [Switch] $UseStructure,
 
         [Parameter()]
-        $Schema
+        [Switch] $UseSchema
     )
 
     $TypeProperties = [PSCustomObject]@{
@@ -43,6 +43,6 @@ function New-AzureDatabricksDeltaLakeTable {
         -TypeProperties $TypeProperties `
         -LinkedServiceReference:$LinkedServiceReference `
         -Parameters:$Parameters `
-        -Structure $Structure `
-        -Schema $Schema
+        -UseStructure:$UseStructure `
+        -UseSchema:$UseSchema
 }

--- a/src/Public/New-AzureDatabricksDeltaLakeTable.ps1
+++ b/src/Public/New-AzureDatabricksDeltaLakeTable.ps1
@@ -22,13 +22,7 @@ function New-AzureDatabricksDeltaLakeTable {
 
         [Parameter( Mandatory )]
         [ValidateNotNullOrEmpty()]
-        [string] $TableName,
-
-        [Parameter()]
-        [Switch] $UseStructure,
-
-        [Parameter()]
-        [Switch] $UseSchema
+        [string] $TableName
     )
 
     $TypeProperties = [PSCustomObject]@{
@@ -43,5 +37,5 @@ function New-AzureDatabricksDeltaLakeTable {
         -TypeProperties $TypeProperties `
         -LinkedServiceReference:$LinkedServiceReference `
         -Parameters:$Parameters `
-        -StructureOrSchema 'schema'
+        -SchemaType 'schema'
 }

--- a/src/Public/New-AzureDatabricksDeltaLakeTable.ps1
+++ b/src/Public/New-AzureDatabricksDeltaLakeTable.ps1
@@ -43,6 +43,5 @@ function New-AzureDatabricksDeltaLakeTable {
         -TypeProperties $TypeProperties `
         -LinkedServiceReference:$LinkedServiceReference `
         -Parameters:$Parameters `
-        -UseStructure:$UseStructure `
-        -UseSchema:$UseSchema
+        -StructureOrSchema 'schema'
 }

--- a/src/Public/New-AzureDatabricksDeltaLakeTable.ps1
+++ b/src/Public/New-AzureDatabricksDeltaLakeTable.ps1
@@ -22,7 +22,13 @@ function New-AzureDatabricksDeltaLakeTable {
 
         [Parameter( Mandatory )]
         [ValidateNotNullOrEmpty()]
-        [string] $TableName
+        [string] $TableName,
+
+        [Parameter()]
+        $Structure,
+
+        [Parameter()]
+        $Schema
     )
 
     $TypeProperties = [PSCustomObject]@{
@@ -36,5 +42,7 @@ function New-AzureDatabricksDeltaLakeTable {
         -Type AzureDatabricksDeltaLakeDataset `
         -TypeProperties $TypeProperties `
         -LinkedServiceReference:$LinkedServiceReference `
-        -Parameters:$Parameters
+        -Parameters:$Parameters `
+        -Structure $Structure `
+        -Schema $Schema
 }

--- a/src/Public/New-AzureDatabricksDeltaLakeTable.ps1
+++ b/src/Public/New-AzureDatabricksDeltaLakeTable.ps1
@@ -18,11 +18,16 @@ function New-AzureDatabricksDeltaLakeTable {
 
         [Parameter( Mandatory )]
         [ValidateNotNullOrEmpty()]
-        $TableName
+        [string] $SchemaName,
+
+        [Parameter( Mandatory )]
+        [ValidateNotNullOrEmpty()]
+        [string] $TableName
     )
 
     $TypeProperties = [PSCustomObject]@{
-        tableName = $TableName
+        database = $SchemaName
+        table = $TableName
     }
 
     New-Dataset `

--- a/src/Public/New-AzureSqlTable.ps1
+++ b/src/Public/New-AzureSqlTable.ps1
@@ -32,5 +32,5 @@ function New-AzureSqlTable {
         -TypeProperties $TypeProperties `
         -LinkedServiceReference:$LinkedServiceReference `
         -Parameters:$Parameters `
-        -StructureOrSchema 'structure'
+        -SchemaType 'structure'
 }

--- a/src/Public/New-AzureSqlTable.ps1
+++ b/src/Public/New-AzureSqlTable.ps1
@@ -32,5 +32,5 @@ function New-AzureSqlTable {
         -TypeProperties $TypeProperties `
         -LinkedServiceReference:$LinkedServiceReference `
         -Parameters:$Parameters `
-        -UseStructure
+        -StructureOrSchema 'structure'
 }

--- a/src/Public/New-AzureSqlTable.ps1
+++ b/src/Public/New-AzureSqlTable.ps1
@@ -31,5 +31,6 @@ function New-AzureSqlTable {
         -Type AzureSqlTable `
         -TypeProperties $TypeProperties `
         -LinkedServiceReference:$LinkedServiceReference `
-        -Parameters:$Parameters
+        -Parameters:$Parameters `
+        -UseStructure
 }

--- a/src/Public/New-CopyActivity.ps1
+++ b/src/Public/New-CopyActivity.ps1
@@ -63,7 +63,7 @@ function New-CopyActivity {
     $activity.typeProperties | Add-Member sink ([PSCustomObject] @{
             type = $SinkType
         })
-    
+
     if ($SinkStagingSettings) {
         $activity.typeProperties | Add-Member enableStaging $true
         $activity.typeProperties | Add-Member stagingSettings $SinkStagingSettings
@@ -71,7 +71,7 @@ function New-CopyActivity {
     else {
         $activity.typeProperties | Add-Member enableStaging $false
     }
-    
+
 
     if ( $SourceQueryTimeout ) {
         $activity.typeProperties.source | Add-Member queryTimeout $SourceQueryTimeout
@@ -83,6 +83,12 @@ function New-CopyActivity {
 
     if ( $SqlWriterUseTableLock.IsPresent ) {
         $activity.typeProperties.sink | Add-Member sqlWriterUseTableLock $true
+    }
+
+    if ( $SinkType -eq 'AzureDatabricksDeltaLakeSink' ) {
+        $activity.typeProperties.sink | Add-Member importSettings ([PSCustomObject] @{
+            type = "AzureDatabricksDeltaLakeImportCommand"
+        })
     }
 
     if ( $Translator ) {

--- a/src/Public/New-DelimitedTextDataset.ps1
+++ b/src/Public/New-DelimitedTextDataset.ps1
@@ -34,7 +34,13 @@ function New-DelimitedTextDataset {
 
         [Parameter( Mandatory )]
         [ValidateNotNullOrEmpty()]
-        [string] $QuoteChar
+        [string] $QuoteChar,
+
+        [Parameter()]
+        $Structure,
+
+        [Parameter()]
+        $Schema
     )
 
     $TypeProperties = [PSCustomObject]@{
@@ -51,5 +57,7 @@ function New-DelimitedTextDataset {
         -Type DelimitedText `
         -TypeProperties $TypeProperties `
         -LinkedServiceReference:$LinkedServiceReference `
-        -Parameters:$Parameters
+        -Parameters:$Parameters `
+        -Structure $Structure `
+        -Schema $Schema
 }

--- a/src/Public/New-DelimitedTextDataset.ps1
+++ b/src/Public/New-DelimitedTextDataset.ps1
@@ -34,13 +34,7 @@ function New-DelimitedTextDataset {
 
         [Parameter( Mandatory )]
         [ValidateNotNullOrEmpty()]
-        [string] $QuoteChar,
-
-        [Parameter( )]
-        [switch] $UseStructure,
-
-        [Parameter( )]
-        [switch] $UseSchema
+        [string] $QuoteChar
     )
 
     $TypeProperties = [PSCustomObject]@{
@@ -58,5 +52,5 @@ function New-DelimitedTextDataset {
         -TypeProperties $TypeProperties `
         -LinkedServiceReference:$LinkedServiceReference `
         -Parameters:$Parameters `
-        -StructureOrSchema 'structure'
+        -SchemaType 'structure'
 }

--- a/src/Public/New-DelimitedTextDataset.ps1
+++ b/src/Public/New-DelimitedTextDataset.ps1
@@ -18,11 +18,31 @@ function New-DelimitedTextDataset {
 
         [Parameter( Mandatory )]
         [ValidateNotNullOrEmpty()]
-        $TableName
+        [PSCustomObject] $Location,
+
+        [Parameter( Mandatory )]
+        [ValidateNotNullOrEmpty()]
+        [string] $ColumnDelimiter,
+
+        [Parameter( Mandatory )]
+        [ValidateNotNullOrEmpty()]
+        [string] $EscapeChar,
+
+        [Parameter( Mandatory )]
+        [ValidateNotNullOrEmpty()]
+        [bool] $FirstRowAsHeader,
+
+        [Parameter( Mandatory )]
+        [ValidateNotNullOrEmpty()]
+        [string] $QuoteChar
     )
 
     $TypeProperties = [PSCustomObject]@{
-        tableName = $TableName
+        location = $Location
+        columnDelimiter = $ColumnDelimiter
+        escapeChar = $EscapeChar
+        firstRowAsHeader = $FirstRowAsHeader
+        quoteChar = $QuoteChar
     }
 
     New-Dataset `

--- a/src/Public/New-DelimitedTextDataset.ps1
+++ b/src/Public/New-DelimitedTextDataset.ps1
@@ -52,5 +52,5 @@ function New-DelimitedTextDataset {
         -TypeProperties $TypeProperties `
         -LinkedServiceReference:$LinkedServiceReference `
         -Parameters:$Parameters `
-        -SchemaType 'structure'
+        -SchemaType 'schema'
 }

--- a/src/Public/New-DelimitedTextDataset.ps1
+++ b/src/Public/New-DelimitedTextDataset.ps1
@@ -36,11 +36,11 @@ function New-DelimitedTextDataset {
         [ValidateNotNullOrEmpty()]
         [string] $QuoteChar,
 
-        [Parameter()]
-        $Structure,
+        [Parameter( )]
+        [switch] $UseStructure,
 
-        [Parameter()]
-        $Schema
+        [Parameter( )]
+        [switch] $UseSchema
     )
 
     $TypeProperties = [PSCustomObject]@{
@@ -58,6 +58,6 @@ function New-DelimitedTextDataset {
         -TypeProperties $TypeProperties `
         -LinkedServiceReference:$LinkedServiceReference `
         -Parameters:$Parameters `
-        -Structure $Structure `
-        -Schema $Schema
+        -UseStructure:$UseStructure `
+        -UseSchema:$UseSchema
 }

--- a/src/Public/New-DelimitedTextDataset.ps1
+++ b/src/Public/New-DelimitedTextDataset.ps1
@@ -58,6 +58,5 @@ function New-DelimitedTextDataset {
         -TypeProperties $TypeProperties `
         -LinkedServiceReference:$LinkedServiceReference `
         -Parameters:$Parameters `
-        -UseStructure:$UseStructure `
-        -UseSchema:$UseSchema
+        -StructureOrSchema 'structure'
 }

--- a/test/New-AzureDatabricksDeltaLakeTable.Tests.ps1
+++ b/test/New-AzureDatabricksDeltaLakeTable.Tests.ps1
@@ -11,6 +11,6 @@ Describe New-AzureDatabricksDeltaLakeTable {
     }
 
     It 'works with Schema' {
-        New-AdfAzureDatabricksDeltaLakeTable -Name MyDataset -SchemaName MySchema -TableName MyTable -LinkedServiceReference $LinkedServiceReference -UseSchema -ErrorAction Stop
+        New-AdfAzureDatabricksDeltaLakeTable -Name MyDataset -SchemaName MySchema -TableName MyTable -LinkedServiceReference $LinkedServiceReference -ErrorAction Stop
     }
 }

--- a/test/New-AzureDatabricksDeltaLakeTable.Tests.ps1
+++ b/test/New-AzureDatabricksDeltaLakeTable.Tests.ps1
@@ -10,7 +10,7 @@ Describe New-AzureDatabricksDeltaLakeTable {
         $LinkedServiceReference = New-AdfLinkedServiceReference -Name MyLinkedService
     }
 
-    It works {
-        New-AdfAzureDatabricksDeltaLakeTable -Name MyDataset -SchemaName MySchema -TableName MyTable -LinkedServiceReference $LinkedServiceReference -ErrorAction Stop
+    It 'works with Schema' {
+        New-AdfAzureDatabricksDeltaLakeTable -Name MyDataset -SchemaName MySchema -TableName MyTable -LinkedServiceReference $LinkedServiceReference -UseSchema -ErrorAction Stop
     }
 }

--- a/test/New-AzureDatabricksDeltaLakeTable.Tests.ps1
+++ b/test/New-AzureDatabricksDeltaLakeTable.Tests.ps1
@@ -1,7 +1,7 @@
 #Requires -Modules @{ ModuleName='Pester'; ModuleVersion='5.0.0' }, PsDac
 
 Describe New-AzureDatabricksDeltaLakeTable {
-    
+
     BeforeAll {
         Import-Module $PSScriptRoot\..\src\PsDataFactory.psd1 -Force -ErrorAction Stop
     }
@@ -11,6 +11,6 @@ Describe New-AzureDatabricksDeltaLakeTable {
     }
 
     It works {
-        New-AdfAzureDatabricksDeltaLakeTable -Name MyDataset -TableName MyTable -LinkedServiceReference $LinkedServiceReference -ErrorAction Stop
+        New-AdfAzureDatabricksDeltaLakeTable -Name MyDataset -SchemaName MySchema -TableName MyTable -LinkedServiceReference $LinkedServiceReference -ErrorAction Stop
     }
 }

--- a/test/New-AzureSqlTable.Tests.ps1
+++ b/test/New-AzureSqlTable.Tests.ps1
@@ -1,7 +1,7 @@
 #Requires -Modules @{ ModuleName='Pester'; ModuleVersion='5.0.0' }, PsDac
 
 Describe New-AzureSqlTable {
-    
+
     BeforeAll {
         Import-Module $PSScriptRoot\..\src\PsDataFactory.psd1 -Force -ErrorAction Stop
     }

--- a/test/New-CopyActivity.Tests.ps1
+++ b/test/New-CopyActivity.Tests.ps1
@@ -1,7 +1,7 @@
 #Requires -Modules @{ ModuleName='Pester'; ModuleVersion='5.0.0' }, PsDac
 
 Describe New-CopyActivity {
-    
+
     BeforeAll {
         Import-Module $PSScriptRoot\..\src\PsDataFactory.psd1 -Force -ErrorAction Stop
     }
@@ -14,5 +14,10 @@ Describe New-CopyActivity {
 
     It works {
         New-AdfCopyActivity -Name MyCopyActivity -Source $Source -SourceType AzureSqlSource -Sink $Sink -SinkType AzureSqlSink -ErrorAction Stop
+    }
+
+    It AzureDatabricksDeltaLakeSink {
+        $CopyActivity = New-AdfCopyActivity -Name MyCopyActivity -Source $Source -SourceType AzureSqlSource -Sink $Sink -SinkType AzureDatabricksDeltaLakeSink -ErrorAction Stop
+        $CopyActivity.typeProperties.sink.importSettings.type | Should -Be 'AzureDatabricksDeltaLakeImportCommand'
     }
 }

--- a/test/New-CopyActivity.Tests.ps1
+++ b/test/New-CopyActivity.Tests.ps1
@@ -25,7 +25,7 @@ Describe New-CopyActivity {
         BeforeEach {
             $LinkedServiceReference = New-AdfLinkedServiceReference -Name MyLinkedService
             $Source = New-AdfAzureSqlTable -Name MySourceDataset -TableName MyTable -LinkedServiceReference $LinkedServiceReference
-            $Sink = New-AdfAzureDatabricksDeltaLakeTable -Name MySinkDataset -SchemaName MySchema -TableName MyTable -LinkedServiceReference $LinkedServiceReference -UseSchema
+            $Sink = New-AdfAzureDatabricksDeltaLakeTable -Name MySinkDataset -SchemaName MySchema -TableName MyTable -LinkedServiceReference $LinkedServiceReference
         }
 
         It 'has importSetting type' {

--- a/test/New-CopyActivity.Tests.ps1
+++ b/test/New-CopyActivity.Tests.ps1
@@ -6,18 +6,34 @@ Describe New-CopyActivity {
         Import-Module $PSScriptRoot\..\src\PsDataFactory.psd1 -Force -ErrorAction Stop
     }
 
-    BeforeEach {
-        $LinkedServiceReference = New-AdfLinkedServiceReference -Name MyLinkedService
-        $Source = New-AdfAzureSqlTable -Name MySourceDataset -TableName MyTable -LinkedServiceReference $LinkedServiceReference
-        $Sink = New-AdfAzureSqlTable -Name MySinkDataset -TableName MyTable -LinkedServiceReference $LinkedServiceReference
+    Context AzureDatabricks {
+
+        BeforeEach {
+            $LinkedServiceReference = New-AdfLinkedServiceReference -Name MyLinkedService
+            $Source = New-AdfAzureSqlTable -Name MySourceDataset -TableName MyTable -LinkedServiceReference $LinkedServiceReference
+            $Sink = New-AdfAzureSqlTable  -Name MySinkDataset -TableName MyTable -LinkedServiceReference $LinkedServiceReference
+        }
+
+        It works {
+            New-AdfCopyActivity -Name MyCopyActivity -Source $Source -SourceType AzureSqlSource -Sink $Sink -SinkType AzureSqlSink -ErrorAction Stop
+        }
+
     }
 
-    It works {
-        New-AdfCopyActivity -Name MyCopyActivity -Source $Source -SourceType AzureSqlSource -Sink $Sink -SinkType AzureSqlSink -ErrorAction Stop
+    Context AzureDatabricks {
+
+        BeforeEach {
+            $LinkedServiceReference = New-AdfLinkedServiceReference -Name MyLinkedService
+            $Source = New-AdfAzureSqlTable -Name MySourceDataset -TableName MyTable -LinkedServiceReference $LinkedServiceReference
+            $Sink = New-AdfAzureDatabricksDeltaLakeTable -Name MySinkDataset -SchemaName MySchema -TableName MyTable -LinkedServiceReference $LinkedServiceReference -UseSchema
+        }
+
+        It 'has importSetting type' {
+            $CopyActivity = New-AdfCopyActivity -Name MyCopyActivity -Source $Source -SourceType AzureSqlSource -Sink $Sink -SinkType AzureDatabricksDeltaLakeSink -ErrorAction Stop
+            $CopyActivity.typeProperties.sink.importSettings.type | Should -Be 'AzureDatabricksDeltaLakeImportCommand'
+        }
+
     }
 
-    It AzureDatabricksDeltaLakeSink {
-        $CopyActivity = New-AdfCopyActivity -Name MyCopyActivity -Source $Source -SourceType AzureSqlSource -Sink $Sink -SinkType AzureDatabricksDeltaLakeSink -ErrorAction Stop
-        $CopyActivity.typeProperties.sink.importSettings.type | Should -Be 'AzureDatabricksDeltaLakeImportCommand'
-    }
+
 }

--- a/test/New-DelimitedText.Tests.ps1
+++ b/test/New-DelimitedText.Tests.ps1
@@ -1,7 +1,7 @@
 #Requires -Modules @{ ModuleName='Pester'; ModuleVersion='5.0.0' }, PsDac
 
 Describe New-DelimitedText {
-    
+
     BeforeAll {
         Import-Module $PSScriptRoot\..\src\PsDataFactory.psd1 -Force -ErrorAction Stop
     }
@@ -11,6 +11,18 @@ Describe New-DelimitedText {
     }
 
     It works {
-        New-AdfDelimitedTextDataset -Name MyDataset -TableName MyTable -LinkedServiceReference $LinkedServiceReference -ErrorAction Stop
+        New-AdfDelimitedTextDataset `
+            -Name MyDataset `
+            -LinkedServiceReference $LinkedServiceReference `
+            -Location ([PSCustomObject]@{
+                type = "type"
+                folderPath = "folderPath"
+                container = "contain"
+            }) `
+            -ColumnDelimiter "`t" `
+            -EscapeChar "`\" `
+            -FirstRowAsHeader $true `
+            -QuoteChar "`"" `
+            -ErrorAction Stop
     }
 }


### PR DESCRIPTION

Change typeProperties for New-DelimitedText to:
```json
"typeProperties": {
    "location": {
        "type": "string",
        "fileName": "string",
        "folderPath": "string",
        "container": "string"
    },
    "columnDelimiter": "\t",
    "escapeChar": "\\",
    "firstRowAsHeader": true,
    "quoteChar": "\""
}
```

Change typeProperties for New-AzureDatabricksDeltaLakeTable to:
```json
"typeProperties": {
    "database": "string",
    "table": "string"
}
```
